### PR TITLE
past-events: fix logo references

### DIFF
--- a/docs/past-events/2021.md
+++ b/docs/past-events/2021.md
@@ -78,41 +78,41 @@ We're looking for sponsors to cover expenses such as venue, catering, pavilion t
 
 ### Gold
 
-![Serokell is an international R&D company that specializes in PLT, protocols, biotech and machine learning](assets/2021/logo-black.png)
+![Serokell is an international R&D company that specializes in PLT, protocols, biotech and machine learning](/assets/2021/logo-black.png)
 
 Serokell is an international R&D company that specializes in PLT, protocols, biotech and machine learning
 
 ### Silver
 
-![[cyberus-technology.de](http://cyberus-technology.de/) - Secure and Fast Intel Virtualization](assets/2021/cyberus-logo.png)
+![[cyberus-technology.de](http://cyberus-technology.de/) - Secure and Fast Intel Virtualization](/assets/2021/cyberus-logo.png)
 
 [cyberus-technology.de](http://cyberus-technology.de/) - Secure and Fast Intel Virtualization
 
-![[numtide.com](http://numtide.com) - NixOS and DevOps consulting](assets/2021/numtide-logo.png)
+![[numtide.com](http://numtide.com) - NixOS and DevOps consulting](/assets/2021/numtide-logo.png)
 
 [numtide.com](http://numtide.com) - NixOS and DevOps consulting
 
-![[pnsol.com](http://www.pnsol.com/) - Dependable performance by design](assets/2021/pns.png)
+![[pnsol.com](http://www.pnsol.com/) - Dependable performance by design](/assets/2021/pns.png)
 
 [pnsol.com](http://www.pnsol.com/) - Dependable performance by design
 
-![[hypered.io](https://hypered.io/) - Software development, defined](assets/2021/hypered-1040x685_(1).svg)
+![[hypered.io](https://hypered.io/) - Software development, defined](/assets/2021/hypered-1040x685_(1).svg)
 
 [hypered.io](https://hypered.io/) - Software development, defined
 
 ### Bronze
 
-![[hercules-ci.com/](http://hercules-ci.com/) - Nix-first CI/CD](assets/2021/hercules-logo-rendered-960.png)
+![[hercules-ci.com/](http://hercules-ci.com/) - Nix-first CI/CD](/assets/2021/hercules-logo-rendered-960.png)
 
 [hercules-ci.com/](http://hercules-ci.com/) - Nix-first CI/CD
 
 ### Organizers
 
-![[cachix.org](https://cachix.org/) - Nix binary cache hosting](assets/2021/logo-small.png)
+![[cachix.org](https://cachix.org/) - Nix binary cache hosting](/assets/2021/logo-small.png)
 
 [cachix.org](https://cachix.org/) - Nix binary cache hosting
 
-![[niteo.co](https://niteo.co/) - SaaS studio transitioning to Nix](assets/2021/Niteo-02.png)
+![[niteo.co](https://niteo.co/) - SaaS studio transitioning to Nix](/assets/2021/Niteo-02.png)
 
 [niteo.co](https://niteo.co/) - SaaS studio transitioning to Nix
 

--- a/docs/past-events/2022-april.md
+++ b/docs/past-events/2022-april.md
@@ -79,49 +79,49 @@ We're looking for sponsors to cover expenses such as venue, catering, pavilion t
 
 ### Gold
 
-![[Platonic.systems](http://Platonic.systems) - **Solving your toughest software problems**](assets/2022-1/logo.svg)
+![[Platonic.systems](http://Platonic.systems) - **Solving your toughest software problems**](/assets/2022-1/logo.svg)
 
 [Platonic.systems](http://Platonic.systems) - **Solving your toughest software problems**
 
 ### Silver
 
 ![[cyberus-technology.de](http://cyberus-technology.de/)
- - Secure and Fast Intel Virtualization](assets/2022-1/cyberus.png)
+ - Secure and Fast Intel Virtualization](/assets/2022-1/cyberus.png)
 
 [cyberus-technology.de](http://cyberus-technology.de/)
  - Secure and Fast Intel Virtualization
 
-![Building products to make Nix easier to learn for individuals and easier to scale for teams](assets/2022-1/flox_blue_rgb.png)
+![Building products to make Nix easier to learn for individuals and easier to scale for teams](/assets/2022-1/flox_blue_rgb.png)
 
 Building products to make Nix easier to learn for individuals and easier to scale for teams
 
 ### Bronze
 
 ![[numtide.com](http://numtide.com/)
- - NixOS and DevOps consulting](assets/2022-1/numtide.png)
+ - NixOS and DevOps consulting](/assets/2022-1/numtide.png)
 
 [numtide.com](http://numtide.com/)
  - NixOS and DevOps consulting
 
-![Helsinki Systems - Your partner for hosting, networks and IT solutions running NixOS](assets/2022-1/helsinki-systems.png)
+![Helsinki Systems - Your partner for hosting, networks and IT solutions running NixOS](/assets/2022-1/helsinki-systems.png)
 
 Helsinki Systems - Your partner for hosting, networks and IT solutions running NixOS
 
-![Feeld. Dating for humans.](assets/2022-1/Feeld-LogoLockup-Black-RGB.png)
+![Feeld. Dating for humans.](/assets/2022-1/Feeld-LogoLockup-Black-RGB.png)
 
 Feeld. Dating for humans.
 
-![A software innovation lab that helps deep tech startup](assets/2022-1/logo_tweag_black_with_description.png)
+![A software innovation lab that helps deep tech startup](/assets/2022-1/logo_tweag_black_with_description.png)
 
 A software innovation lab that helps deep tech startup
 
 ### Organizers
 
-![[cachix.org](https://cachix.org/) - Nix binary cache hosting](assets/2022-1/logo-small.png)
+![[cachix.org](https://cachix.org/) - Nix binary cache hosting](/assets/2022-1/logo-small.png)
 
 [cachix.org](https://cachix.org/) - Nix binary cache hosting
 
-![[Pareto Security](https://paretosecurity.com) - Zero-trust device monitoring for remote teams](assets/2022-1/logo_copy.png)
+![[Pareto Security](https://paretosecurity.com) - Zero-trust device monitoring for remote teams](/assets/2022-1/logo_copy.png)
 
 [Pareto Security](https://paretosecurity.com) - Zero-trust device monitoring for remote teams
 

--- a/docs/past-events/2022-november.md
+++ b/docs/past-events/2022-november.md
@@ -86,35 +86,35 @@ We're looking for sponsors to cover expenses such as venue, catering, pavilion t
 
 ### Gold
 
-![nixos.svg](assets/2022-2/nixos.svg)
+![nixos.svg](/assets/2022-2/nixos.svg)
 
 ### Silver
 
-![supercede.svg](assets/2022-2/supercede.svg)
+![supercede.svg](/assets/2022-2/supercede.svg)
 
-![flox.png](assets/2022-2/flox.png)
+![flox.png](/assets/2022-2/flox.png)
 
-![determinate_systems.svg](assets/2022-2/determinate_systems.svg)
+![determinate_systems.svg](/assets/2022-2/determinate_systems.svg)
 
-![secunet.svg](assets/2022-2/secunet.svg)
+![secunet.svg](/assets/2022-2/secunet.svg)
 
-![cyberus.svg](assets/2022-2/cyberus.svg)
+![cyberus.svg](/assets/2022-2/cyberus.svg)
 
 ### Bronze
 
-![hercules-logo-rendered-960.png](assets/2022-2/hercules-logo-rendered-960.png)
+![hercules-logo-rendered-960.png](/assets/2022-2/hercules-logo-rendered-960.png)
 
-![logo_tweag_black_with_description (1).png](assets/2022-2/logo_tweag_black_with_description_(1).png)
+![logo_tweag_black_with_description (1).png](/assets/2022-2/logo_tweag_black_with_description_(1).png)
 
-![hypered-1040x685 (1) (1).svg](assets/2022-2/hypered-1040x685_(1)_(1).svg)
+![hypered-1040x685 (1) (1).svg](/assets/2022-2/hypered-1040x685_(1)_(1).svg)
 
 ### Organizers
 
-![[cachix.org](https://cachix.org/) - Nix binary cache hosting](assets/2022-2/logo-small.png)
+![[cachix.org](https://cachix.org/) - Nix binary cache hosting](/assets/2022-2/logo-small.png)
 
 [cachix.org](https://cachix.org/) - Nix binary cache hosting
 
-![[Pareto Security](https://paretosecurity.com) - Zero-trust device monitoring for remote teams](assets/2022-2/logo_copy.png)
+![[Pareto Security](https://paretosecurity.com) - Zero-trust device monitoring for remote teams](/assets/2022-2/logo_copy.png)
 
 [Pareto Security](https://paretosecurity.com) - Zero-trust device monitoring for remote teams
 

--- a/docs/past-events/2023.md
+++ b/docs/past-events/2023.md
@@ -106,24 +106,24 @@ Our target budget is 15000 EUR. Reach out to [sponsors@oceansprint.org](mailto:s
 
 ### 🏆 Gold
 
-![mercury](./assets/logos/mercury.svg){: style="width:400px; margin:20px"}
-![numtide](./assets/logos/numtide.svg){: style="width:400px; margin:20px"}
-![secunet](./assets/logos/secunet.svg){: style="width:400px; margin:20px"}
-![nixos](./assets/logos/nixos.svg){: style="width:400px; margin:20px"}
-![casper](./assets/logos/casper.svg){: style="width:400px; margin:20px"}
+![mercury](/assets/logos/mercury.svg){: style="width:400px; margin:20px"}
+![numtide](/assets/logos/numtide.svg){: style="width:400px; margin:20px"}
+![secunet](/assets/logos/secunet.svg){: style="width:400px; margin:20px"}
+![nixos](/assets/logos/nixos.svg){: style="width:400px; margin:20px"}
+![casper](/assets/logos/casper.svg){: style="width:400px; margin:20px"}
 
 ### 🏢 Company
 
-![Cyberus Technology](./assets/logos/cyberus.svg){: style="width:250px; margin:20px"}
-![Flox](./assets/logos/flox.svg){: style="width:250px; margin:20px"}
-![Flokli](./assets/logos/flokli.svg){: style="width:250px; margin:20px"}
-![Namespace Labs](./assets/logos/namespace.svg){: style="width:250px; margin:20px"}
-![supercede](./assets/logos/supercede.svg){: style="width:250px; margin:20px"}
+![Cyberus Technology](/assets/logos/cyberus.svg){: style="width:250px; margin:20px"}
+![Flox](/assets/logos/flox.svg){: style="width:250px; margin:20px"}
+![Flokli](/assets/logos/flokli.svg){: style="width:250px; margin:20px"}
+![Namespace Labs](/assets/logos/namespace.svg){: style="width:250px; margin:20px"}
+![supercede](/assets/logos/supercede.svg){: style="width:250px; margin:20px"}
 
 ### 💻 Individual
 
-![Hercules CI](./assets/2022-2/hercules-logo-rendered-960.png){: style="width:200px; margin:20px"}
-![Nixcademy](./assets/logos/nixcademy.svg){: style="width:200px; margin:20px"}
+![Hercules CI](/assets/2022-2/hercules-logo-rendered-960.png){: style="width:200px; margin:20px"}
+![Nixcademy](/assets/logos/nixcademy.svg){: style="width:200px; margin:20px"}
 
 - Ryan Hill
 

--- a/docs/past-events/2025.md
+++ b/docs/past-events/2025.md
@@ -358,41 +358,41 @@
     <h4 class="font-medium text-gray-500 uppercase text-sm tracking-wider mb-3">Gold Sponsors</h4>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-12">
       <div class="flex items-center justify-center p-6 border border-gray-100 shadow-sm rounded-lg h-32">
-        <img src="./assets/logos/numtide.svg" alt="numtide" class="w-full h-full object-contain">
+        <img src="/assets/logos/numtide.svg" alt="numtide" class="w-full h-full object-contain">
       </div>
       <div class="flex items-center justify-center p-6 border border-gray-100 shadow-sm rounded-lg h-32">
-        <img src="./assets/logos/mercury.svg" alt="mercury" class="w-full h-full object-contain">
+        <img src="/assets/logos/mercury.svg" alt="mercury" class="w-full h-full object-contain">
       </div>
       <div class="flex items-center justify-center p-6 border border-gray-100 shadow-sm rounded-lg h-32">
-        <img src="./assets/logos/secunet.svg" alt="secunet" class="w-full h-full object-contain">
+        <img src="/assets/logos/secunet.svg" alt="secunet" class="w-full h-full object-contain">
       </div>
       <div class="flex items-center justify-center p-6 border border-gray-100 shadow-sm rounded-lg h-32">
-        <img src="./assets/logos/clan.svg" alt="clan.lol" class="w-full h-full object-contain">
+        <img src="/assets/logos/clan.svg" alt="clan.lol" class="w-full h-full object-contain">
       </div>
       <div class="flex items-center justify-center p-6 border border-gray-100 shadow-sm rounded-lg h-32">
-        <img src="./assets/logos/shopify.svg" alt="shopify" class="w-full h-full object-contain">
+        <img src="/assets/logos/shopify.svg" alt="shopify" class="w-full h-full object-contain">
       </div>
       <div class="flex items-center justify-center p-6 border border-gray-100 shadow-sm rounded-lg h-32">
-        <img src="./assets/logos/nixos.svg" alt="nixos" class="w-full h-full object-contain">
+        <img src="/assets/logos/nixos.svg" alt="nixos" class="w-full h-full object-contain">
       </div>
     </div>
 
     <h4 class="font-medium text-gray-500 uppercase text-sm tracking-wider mb-3">Company Sponsors</h4>
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
       <div class="flex items-center justify-center p-3 border border-gray-100 h-16">
-        <img src="./assets/logos/nixcademy.svg" alt="nixcademy" class="w-full h-full object-contain">
+        <img src="/assets/logos/nixcademy.svg" alt="nixcademy" class="w-full h-full object-contain">
       </div>
       <div class="flex items-center justify-center p-3 border border-gray-100 h-16">
-        <img src="./assets/logos/cyberus.png" alt="cyberus" class="w-full h-full object-contain">
+        <img src="/assets/logos/cyberus.png" alt="cyberus" class="w-full h-full object-contain">
       </div>
       <div class="flex items-center justify-center p-3 border border-gray-100 h-16">
-        <img src="./assets/logos/flox.svg" alt="flox" class="w-full h-full object-contain">
+        <img src="/assets/logos/flox.svg" alt="flox" class="w-full h-full object-contain">
       </div>
       <div class="flex items-center justify-center p-3 border border-gray-100 h-16">
-        <img src="./assets/logos/flying_circus.svg" alt="flyingcircus" class="w-full h-full object-contain">
+        <img src="/assets/logos/flying_circus.svg" alt="flyingcircus" class="w-full h-full object-contain">
       </div>
       <div class="flex items-center justify-center p-3 border border-gray-100 h-16">
-        <img src="./assets/logos/supercede.svg" alt="supercede" class="w-full h-full object-contain">
+        <img src="/assets/logos/supercede.svg" alt="supercede" class="w-full h-full object-contain">
       </div>
     </div>
   </div>


### PR DESCRIPTION
I just noticed the missing logos on the 2025 page and then saw that the previous ones are also affected.

Not sure if you'd like to move this year's logos to their own asset folder now, or when sponsors for the 2026 iteration are set.